### PR TITLE
tools: Make clang-format-diff.py use versioned files, not local files

### DIFF
--- a/tools/clang-format/clang-format-diff.py
+++ b/tools/clang-format/clang-format-diff.py
@@ -139,7 +139,7 @@ def main():
     if not args.i:
       formatted_code = StringIO(stdout).readlines()
       diff = difflib.unified_diff(code, formatted_code,
-                                  filename, tmpfile.name,
+                                  filename, filename,
                                   '(before formatting)', '(after formatting)')
       diff_string = ''.join(diff)
       if len(diff_string) > 0:


### PR DESCRIPTION
clang-format-diff.py uses the 'diff' passed in stdin to know which files
to pass to clang-format. clang-format then uses the *local* versions of those
files to check any formatting issues: then if formatting is correct locally
but not on HEAD (which is currently being pushed), the script does not
complain and then we can push unformatted source files.

Fix that by checkouting those files into /tmp directory and make clang-format
work on the temp files.